### PR TITLE
US108515: [Bug] Label in filter is not displaying correct names for S3-buckets in the JIra Plugin

### DIFF
--- a/src/main/resources/js/services/AUIUtilsService.js
+++ b/src/main/resources/js/services/AUIUtilsService.js
@@ -228,7 +228,7 @@ var AUIUtilsService = function() {
                     }
                     return filter.name;
                 }
-                return "("+filter.bucket_name+")";
+                return "("+self.getLastDetailFromKey(filter.key)+")";
             }
 
             if (filter.type === "region") {


### PR DESCRIPTION
Filter name got from the key when bucket_name and name doesn't exist